### PR TITLE
[FIX] - Patch image registry Management State

### DIFF
--- a/ocp4_setup_upi_kvm.sh
+++ b/ocp4_setup_upi_kvm.sh
@@ -1026,6 +1026,16 @@ do
         } || true        
     fi
 
+    if [ "$mgdreg_patched" == "0" ]; then
+        ./oc get configs.imageregistry.operator.openshift.io cluster &> /dev/null && \
+       {
+            sleep 30
+            echo -n '  --> Patching image registry to use Managed management state instead of Removed ';
+            ./oc patch configs.imageregistry.operator.openshift.io/cluster --type merge --p '{"spec":{"managementState": "Managed"}}' 2> /dev/null && \
+                mgdreg_patched=1 || true
+        } || true        
+    fi
+
     if [ "$ingress_patched" == "0" ]; then
         ./oc get -n openshift-ingress-operator ingresscontroller default &> /dev/null && \
         {

--- a/ocp4_setup_upi_kvm.sh
+++ b/ocp4_setup_upi_kvm.sh
@@ -1119,7 +1119,7 @@ do
        {
             sleep 30
             echo -n '  --> Patching image registry to use Managed management state instead of Removed ';
-            ./oc patch configs.imageregistry.operator.openshift.io/cluster --type merge --p '{"spec":{"managementState": "Managed"}}' 2> /dev/null && \
+            ./oc patch configs.imageregistry.operator.openshift.io/cluster --type merge --patch '{"spec":{"managementState": "Managed"}}' 2> /dev/null && \
                 mgdreg_patched=1 || true
         } || true        
     fi


### PR DESCRIPTION
When installing OCP 4 on KVM or Bare Metal the default ManagementState on Registry is "Removed" and this cause an error "an image stream cannot be used as build output because the integrated container image registry is not configured" when deploying a new app.