### PR TITLE
[FIX] Add worker nodes on haproxy.cfg to 80 and 443 port

### DIFF
--- a/ocp4_setup_upi_kvm.sh
+++ b/ocp4_setup_upi_kvm.sh
@@ -734,6 +734,10 @@ for i in $(seq 1 ${N_MAST})
 do
     echo "  server master-${i} master-${i}.${CLUSTER_NAME}.${BASE_DOM}:80 check" >> haproxy.cfg
 done
+for i in $(seq 1 ${N_WORK})
+do
+    echo "  server worker-${i} worker-${i}.${CLUSTER_NAME}.${BASE_DOM}:80 check" >> haproxy.cfg
+done
 echo "
 # 443 points to master nodes
 frontend ${CLUSTER_NAME}-https *:443
@@ -743,6 +747,11 @@ backend infra-https
 for i in $(seq 1 ${N_MAST})
 do
     echo "  server master-${i} master-${i}.${CLUSTER_NAME}.${BASE_DOM}:443 check" >> haproxy.cfg
+done
+
+for i in $(seq 1 ${N_WORK})
+do
+    echo "  server worker-${i} worker-${i}.${CLUSTER_NAME}.${BASE_DOM}:443 check" >> haproxy.cfg
 done
 
 


### PR DESCRIPTION
Sometimes when you're creating a cluster with more than 2 worker nodes the routers pods may run only on worker's nodes and not on master's nodes. This causes an issue when installing a new cluster because the pods on openshift-console does not start and the install script does not finish.

Logs on ocp install script

====> Waiting for clusterversion:                                                                                                                                                                                  
  --> Working towards 4.3.13: 80% complete
  --> Patching image registry to use EmptyDir: config.imageregistry.operator.openshift.io/cluster patched 
  --> Working towards 4.3.13: 96% complete
  --> Working towards 4.3.13: 96% complete, waiting on authentication, clust ...
  --> Working towards 4.3.13: 96% complete
  --> Working towards 4.3.13: 96% complete, waiting on authentication, clust ...
  --> Working towards 4.3.13: 99% complete
  --> Unable to apply 4.3.13: some cluster operators have not yet rolled out
  --> Unable to apply 4.3.13: some cluster operators have not yet rolled out
  --> Unable to apply 4.3.13: some cluster operators have not yet rolled out
  --> Unable to apply 4.3.13: some cluster operators have not yet rolled out
...
  --> Working towards 4.3.13: 99% complete
  --> Unable to apply 4.3.13: some cluster operators have not yet rolled out

Logs on openshift-console pods when this issue occurs:

2020/06/15 01:24:58 auth: error contacting auth provider (retrying in 10s): request to OAuth issuer endpoint https://oauth-openshift.apps.ultra.chiaret.to/oauth/token failed: Head https://oauth-openshift.apps.ultra.chiaret.to: EOF

Routers Pods status:
oc get pods -n openshift-ingress -o wide
NAME                              READY   STATUS    RESTARTS   AGE   IP              NODE                        NOMINATED NODE   READINESS GATES
router-default-77d9c6df5f-89lzr   1/1     Running   0          29m   192.168.1.203   worker-2.ultra.chiaret.to   <none>           <none>
router-default-77d9c6df5f-js9zj   1/1     Running   0          21m   192.168.1.137   worker-4.ultra.chiaret.to   <none>           <none>

Console pods status
oc get pods -n openshift-console
NAME                         READY   STATUS    RESTARTS   AGE
console-56c4dbd75f-hwxld     0/1     Running   4          47m
console-56c4dbd75f-z6pg9     0/1     Running   3          34m
downloads-78d964646c-cqb9k   1/1     Running   0          57m
downloads-78d964646c-sfz7q   1/1     Running   0          57m