### PR TITLE
libvirt might not be active, but do ensure it is enabled.

### DIFF
--- a/.expose_loadbalancer.sh
+++ b/.expose_loadbalancer.sh
@@ -102,4 +102,11 @@ echo "###############################################"
 echo "### PORT FORWARD RULES CREATED SUCCESSFULLY ###"
 echo "###############################################"
 echo
+
+echo "Port forward rules have been created."
+echo "The following hosts need to be defined in DNS so they can be resolved by your clients:"
+echo "  console-openshift-console.apps.${CLUSTER_NAME}.local"
+echo "  api.${CLUSTER_NAME}.local"
+echo "  oauth-openshift.apps.${CLUSTER_NAME}.local"
+
 exit 0

--- a/ocp4_setup_upi_kvm.sh
+++ b/ocp4_setup_upi_kvm.sh
@@ -513,8 +513,8 @@ test -d "$SETUP_DIR" && \
         "You can also use --script-dir to specify a different directory for this installation"
 ok
 
-echo -n "====> Checking if libvirt is running: "
-    systemctl -q is-active libvirtd || err "libvirtd is not running"; ok
+echo -n "====> Checking if libvirt is running or enabled: "
+    systemctl -q is-active libvirtd || systemctl -q is-enabled libvirtd || err "libvirtd is not running nor enabled"
 
 echo -n "====> Checking libvirt network: "
 if [ -n "$VIR_NET_OCT" ]; then


### PR DESCRIPTION
I have Fedora32 Server installed. `libvirtd` is enabled, but it stops after 2 minutes after boottime. It does "wake up" on demand as it is needed. So the script needs to not abort if libvirtd isn't active, but it does need to make sure it is at least enabled.

So in other words, this PR ensures that the libvirtd service it either running or enabled.

To make sure your system will work with the script, at minimum you need to do this: `sudo systemctl enable libvirtd`

You do not actually have to `systemctl start libvirtd` for this to work. That's why this PR is needed. I had libvirtd enabled but not active (indeed, it appears libvirtd service shutdowns after 2 minutes of idle time, but will wake up on demand).

A second thing this PR does is it also adds a message at the end to remind the user what hostnames need to be added to DNS for clients to access the cluster.