### PR TITLE
fix version check - sed expression needs to change

### DIFF
--- a/.install_scripts/version_check.sh
+++ b/.install_scripts/version_check.sh
@@ -23,13 +23,13 @@ else
     fi
 fi
 echo -n "====> Looking up OCP4 client for release $urldir: "
-CLIENT=$(curl -N --fail -qs "${OCP_MIRROR}/${urldir}/" | grep  -m1 "client-linux" | sed 's/.*href="\(openshift-.*\)">open.*/\1/')
+CLIENT=$(curl -N --fail -qs "${OCP_MIRROR}/${urldir}/" | grep  -m1 "client-linux" | sed 's/.*href="\(openshift-.*\)">.*/\1/')
     test -n "$CLIENT" || err "No client found in ${OCP_MIRROR}/${urldir}/"; ok "$CLIENT"
 CLIENT_URL="${OCP_MIRROR}/${urldir}/${CLIENT}"
 echo -n "====> Checking if Client URL is downloadable: "; download check "$CLIENT" "$CLIENT_URL";
 
 echo -n "====> Looking up OCP4 installer for release $urldir: "
-INSTALLER=$(curl -N --fail -qs "${OCP_MIRROR}/${urldir}/" | grep  -m1 "install-linux" | sed 's/.*href="\(openshift-.*\)">open.*/\1/')
+INSTALLER=$(curl -N --fail -qs "${OCP_MIRROR}/${urldir}/" | grep  -m1 "install-linux" | sed 's/.*href="\(openshift-.*\)">.*/\1/')
     test -n "$INSTALLER" || err "No installer found in ${OCP_MIRROR}/${urldir}/"; ok "$INSTALLER"
 INSTALLER_URL="${OCP_MIRROR}/${urldir}/${INSTALLER}"
 echo -n "====> Checking if Installer URL is downloadable: ";  download check "$INSTALLER" "$INSTALLER_URL";
@@ -55,13 +55,13 @@ else
 fi
 
 echo -n "====> Looking up RHCOS kernel for release $RHCOS_VER/$urldir: "
-KERNEL=$(curl -N --fail -qs "${RHCOS_MIRROR}/${RHCOS_VER}/${urldir}/" | grep -m1 "installer-kernel\|live-kernel" | sed 's/.*href="\(rhcos-.*\)">rhcos.*/\1/')
+KERNEL=$(curl -N --fail -qs "${RHCOS_MIRROR}/${RHCOS_VER}/${urldir}/" | grep -m1 "installer-kernel\|live-kernel" | sed 's/.*href="\(rhcos-.*\)">.*/\1/')
     test -n "$KERNEL" || err "No kernel found in ${RHCOS_MIRROR}/${RHCOS_VER}/${urldir}/"; ok "$KERNEL"
 KERNEL_URL="${RHCOS_MIRROR}/${RHCOS_VER}/${urldir}/${KERNEL}"
 echo -n "====> Checking if Kernel URL is downloadable: "; download check "$KERNEL" "$KERNEL_URL";
 
 echo -n "====> Looking up RHCOS initramfs for release $RHCOS_VER/$urldir: "
-INITRAMFS=$(curl -N --fail -qs ${RHCOS_MIRROR}/${RHCOS_VER}/${urldir}/ | grep -m1 "installer-initramfs\|live-initramfs" | sed 's/.*href="\(rhcos-.*\)">rhcos.*/\1/')
+INITRAMFS=$(curl -N --fail -qs ${RHCOS_MIRROR}/${RHCOS_VER}/${urldir}/ | grep -m1 "installer-initramfs\|live-initramfs" | sed 's/.*href="\(rhcos-.*\)">.*/\1/')
     test -n "$INITRAMFS" || err "No initramfs found in ${RHCOS_MIRROR}/${RHCOS_VER}/${urldir}/"; ok "$INITRAMFS"
 INITRAMFS_URL="$RHCOS_MIRROR/${RHCOS_VER}/${urldir}/${INITRAMFS}"
 echo -n "====> Checking if Initramfs URL is downloadable: "; download check "$INITRAMFS" "$INITRAMFS_URL";


### PR DESCRIPTION
I was getting this:

```
====> Checking if Client URL is downloadable: 

[ERROR] https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.9.8/                <a href="openshift-client-linux-4.9.8.tar.gz"> not reachable
```

Issue in `.install_scripts/version_check.sh`:

```
CLIENT=$(curl -N --fail -qs "${OCP_MIRROR}/${urldir}/" | grep  -m1 "client-linux" | sed 's/.*href="\(openshift-.*\)">open.*/\1/')
```

If I execute that command (the curl piped to grep then sed) with the env vars set properly:
```
export OCP_MIRROR="https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
export urldir="stable"
curl -N --fail -qs "${OCP_MIRROR}/${urldir}/" | grep  -m1 "client-linux" | sed 's/.*href="\(openshift-.*\)">open.*/\1/'
```
I get this:
```
                <a href="openshift-client-linux-4.9.13.tar.gz">
```

sed is trying to extract out the tarball filename but sed isn't doing what is expected - its just returning the full \<a href\> element. Not sure what changed in the http response from the mirror, but something must have changed in the past few weeks.

This PR fixes the sed expressions for all tarball requests.
