### PR TITLE
Make Network Type configurable

### DIFF
--- a/.defaults.sh
+++ b/.defaults.sh
@@ -54,6 +54,9 @@ export CLUSTER_NAME="ocp4"
 # -d, --cluster-domain DOMAIN
 export BASE_DOM="local"
 
+# -t, --network-type TYPE
+export NETWORK_TYPE="OpenShiftSDN"
+
 # -z, --dns-dir DIR
 export DNS_DIR="/etc/NetworkManager/dnsmasq.d"
 

--- a/.install_scripts/download_prepare.sh
+++ b/.install_scripts/download_prepare.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo 
+echo
 echo "#####################################################"
 echo "### DOWNLOAD AND PREPARE OPENSHIFT 4 INSTALLATION ###"
 echo "#####################################################"
@@ -29,7 +29,7 @@ elif [ -f "${SSH_PUB_KEY_FILE}" ]; then
 else
     err "Unable to select SSH public key!"
 fi
-    
+
 
 echo -n "====> Downloading OCP Client: "; download get "$CLIENT" "$CLIENT_URL";
 echo -n "====> Downloading OCP Installer: "; download get "$INSTALLER" "$INSTALLER_URL";
@@ -73,7 +73,7 @@ networking:
   clusterNetworks:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  networkType: OpenShiftSDN
+  networkType: ${NETWORK_TYPE}
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/.install_scripts/process_args.sh
+++ b/.install_scripts/process_args.sh
@@ -52,6 +52,11 @@ case $key in
     shift
     shift
     ;;
+    -t|--network-type)
+    export NETWORK_TYPE="$2"
+    shift
+    shift
+    ;;
     -v|--vm-dir)
     export VM_DIR="$2"
     shift

--- a/.install_scripts/show_help.sh
+++ b/.install_scripts/show_help.sh
@@ -31,6 +31,11 @@ Options:
     This will be used to populate .baseDomain in the install-config.yaml file that will be used to install the cluster.
     Default: ${BASE_DOM}
 
+-t, --network-type TYPE
+    OpenShift 4 cluster network type.
+    This will be used to populate .networking.networkType in the install-config.yaml file that will be used to install the cluster.
+    Default: ${NETWORK_TYPE}
+
 -m, --masters N
     Number of master nodes to deploy.
     Default: ${N_MAST}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 | -p, --pull-secret FILE | Location of the pull secret file<br>Default: /root/pull-secret |
 | -c, --cluster-name NAME | OpenShift 4 cluster name<br>Default: ocp4 |
 | -d, --cluster-domain DOMAIN | OpenShift 4 cluster domain<br>Default: local |
+| -t, --network-type TYPE | OpenShift 4 cluster network type<br>Default: OpenShiftSDN |
 | -m, --masters N | Number of masters to deploy<br>Default: 3 |
 | -w, --worker N | Number of workers to deploy<br>Default: 2 |
 | --master-cpu N | Number of CPUs for the master VM(s)<br>Default: 4 |
@@ -68,6 +69,10 @@
     # Deploy OpenShift 4.2.stable on new libvirt network (192.168.155.0/24)
     ./ocp4_setup_upi_kvm.sh --ocp-version 4.2.stable --libvirt-oct 155
     ./ocp4_setup_upi_kvm.sh -O 4.2.stable -N 155
+
+    # Deploy OpenShift 4.15.stable with OVNKubernetes network type
+    ./ocp4_setup_upi_kvm.sh --ocp-version 4.15.stable --network-type OVNKubernetes
+    ./ocp4_setup_upi_kvm.sh -O 4.15.stable -t OVNKubernetes
 
     # Destory the already installed cluster
     ./ocp4_setup_upi_kvm.sh --cluster-name ocp43 --cluster-domain lab.test.com --destroy
@@ -158,7 +163,7 @@ for vm in $(virsh list --all --name --autostart | grep "<CLUSTER-NAME>"); do
 done
 ~~~
 
-Note: Replace `<CLUSTER-NAME>` with the cluster name or any matching string to filter out VMs that you want to set/un-set to be auto-started. 
+Note: Replace `<CLUSTER-NAME>` with the cluster name or any matching string to filter out VMs that you want to set/un-set to be auto-started.
 
 ___
 
@@ -177,7 +182,7 @@ When the bootstrap process is complete, the script waits for clusterversion to b
 ~~~
 
 ~~~
-====> Waiting for clusterversion: 
+====> Waiting for clusterversion:
   --> Working towards 4.3.12: 46% complete
   --> Unable to apply 4.3.12: an unknown error has occurred
   --> Working towards 4.3.12: 61% complete


### PR DESCRIPTION
- Add a -t, --network-type option
- Populate .networking.networkType
- Update help text and README

OpenShift SDN CNI was deprecated as of OCP 4.14. As of OCP 4.15, the network plugin is not an option for new installations. Use the OVN Kubernetes (OVNKubernetes) CNI as an alternative.

Source: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html#ocp-4-15-deprecation-sdn

Fixes kxr/ocp4_setup_upi_kvm#36